### PR TITLE
tweak tests for QuickCheck-2.8.2

### DIFF
--- a/testsrc/TestInfrastructure.hs
+++ b/testsrc/TestInfrastructure.hs
@@ -74,6 +74,7 @@ instance (Arbitrary i) => Arbitrary (FM.FMList i) where
 instance (CoArbitrary i) => CoArbitrary (FM.FMList i) where
     coarbitrary l = coarbitrary (LL.toList l)
 
+#if ! MIN_VERSION_QuickCheck(2,8,2)
 instance (Arbitrary i) => Arbitrary (S.Seq i) where
     arbitrary = sized (\n -> choose (0, n) >>= myVector)
         where myVector n =
@@ -83,6 +84,7 @@ instance (Arbitrary i) => Arbitrary (S.Seq i) where
 
 instance (CoArbitrary i) => CoArbitrary (S.Seq i) where
     coarbitrary l = coarbitrary (LL.toList l)
+#endif
 
 instance Arbitrary (BSL.ByteString) where
     arbitrary = sized (\n -> choose (0, n) >>= myVector)


### PR DESCRIPTION
QuickCheck's commit ce6e6374c4c6c6cb40315f661f0abf4e60ecfbf3
added instances to Seq which led to redeclaration collision:

testsrc/TestInfrastructure.hs:77:10:
    Duplicate instance declarations:
      instance Arbitrary i => Arbitrary (S.Seq i)
        -- Defined at testsrc/TestInfrastructure.hs:77:10
      instance [safe] Arbitrary a => Arbitrary (S.Seq a)
        -- Defined in ‘Test.QuickCheck.Arbitrary’

testsrc/TestInfrastructure.hs:84:10:
    Duplicate instance declarations:
      instance CoArbitrary i => CoArbitrary (S.Seq i)
        -- Defined at testsrc/TestInfrastructure.hs:84:10
      instance [safe] CoArbitrary a => CoArbitrary (S.Seq a)
        -- Defined in ‘Test.QuickCheck.Arbitrary’

Signed-off-by: Sergei Trofimovich <siarheit@google.com>