### PR TITLE
Add stripSuffix and stripPrefix

### DIFF
--- a/src/Data/ListLike.hs
+++ b/src/Data/ListLike.hs
@@ -55,6 +55,8 @@ module Data.ListLike
                  group, inits, tails, 
                  -- ** Predicates
                  isPrefixOf, isSuffixOf, isInfixOf,
+                 -- ** Modify based on predicate
+                 stripPrefix, stripSuffix,
                  -- * Searching lists
                  -- ** Searching by equality
                  elem, notElem,

--- a/src/Data/ListLike/Base.hs
+++ b/src/Data/ListLike/Base.hs
@@ -288,6 +288,19 @@ class (FoldableLL full item, Monoid full) =>
         any (isPrefixOf needle) thetails
         where thetails = asTypeOf (tails haystack) [haystack]
 
+    ------------------------------ Conditionally modify based on predicates
+    {- | Remove a prefix from a listlike if possible -}
+    stripPrefix :: Eq item => full -> full -> Maybe full
+    stripPrefix xs ys = if xs `isPrefixOf` ys
+                            then Just $ drop (length xs) ys
+                            else Nothing
+
+    {- | Remove a suffix from a listlike if possible -}
+    stripSuffix :: Eq item => full -> full -> Maybe full
+    stripSuffix xs ys = if xs `isSuffixOf` ys
+                            then Just $ take (length ys - length xs) ys
+                            else Nothing
+
     ------------------------------ Searching
     {- | True if the item occurs in the list -}
     elem :: Eq item => item -> full -> Bool
@@ -607,6 +620,7 @@ instance ListLike [a] a where
     isPrefixOf = L.isPrefixOf
     isSuffixOf = L.isSuffixOf
     isInfixOf = L.isInfixOf
+    stripPrefix = L.stripPrefix
     elem = L.elem
     notElem = L.notElem
     find = L.find

--- a/src/Data/ListLike/Text/Text.hs
+++ b/src/Data/ListLike/Text/Text.hs
@@ -59,6 +59,8 @@ instance ListLike T.Text Char where
     tails = fromList . T.tails
     isPrefixOf = T.isPrefixOf
     isSuffixOf = T.isSuffixOf
+    stripPrefix = T.stripPrefix
+    stripSuffix = T.stripSuffix
     elem = T.isInfixOf . T.singleton
     find = T.find
     filter = T.filter

--- a/src/Data/ListLike/Text/TextLazy.hs
+++ b/src/Data/ListLike/Text/TextLazy.hs
@@ -58,6 +58,8 @@ instance ListLike T.Text Char where
     tails = fromList . T.tails
     isPrefixOf = T.isPrefixOf
     isSuffixOf = T.isSuffixOf
+    stripPrefix = T.stripPrefix
+    stripSuffix = T.stripSuffix
     elem = T.isInfixOf . T.singleton
     find = T.find
     filter = T.filter

--- a/testsrc/runtests.hs
+++ b/testsrc/runtests.hs
@@ -17,6 +17,7 @@ For license and copyright information, see the file COPYRIGHT
 -}
 module Main where
 
+import Control.Applicative
 import Test.QuickCheck
 import qualified Data.ListLike as LL
 import qualified Data.Foldable as F
@@ -110,6 +111,11 @@ prop_isSuffixOf f1 f2 = LL.isSuffixOf f1 f2 ==
     (isSuffixOf (LL.toList f1) (LL.toList f2))
 prop_isInfixOf f1 f2 = LL.isInfixOf f1 f2 ==
     (isInfixOf (LL.toList f1) (LL.toList f2))
+prop_stripPrefix f1 f2 = (LL.toList <$> LL.stripPrefix f1 f2) ==
+    (stripPrefix (LL.toList f1) (LL.toList f2))
+prop_stripPrefix2 f1 f2 = (LL.toList <$> LL.stripPrefix f1 (f1 <> f2)) ==
+    (stripPrefix (LL.toList f1) (LL.toList $ f1 <> f2))
+prop_stripSuffix f1 f2 = LL.stripSuffix f1 (f2 <> f1) == Just f2
 prop_elem f i = LL.elem i f == elem i (LL.toList f)
 prop_notElem f i = LL.notElem i f == notElem i (LL.toList f)
 prop_find f func = LL.find func f == find func (LL.toList f)
@@ -269,6 +275,9 @@ allt = [apf "empty" (t prop_empty),
         apf "isPrefixOf" (t prop_isPrefixOf),
         apf "isSuffixOf" (t prop_isSuffixOf),
         apf "isInfixOf" (t prop_isInfixOf),
+        apf "stripPrefix" (t prop_stripPrefix),
+        apf "stripPrefix2" (t prop_stripPrefix2),
+        apf "stripSuffix" (t prop_stripSuffix),
         apf "elem" (t prop_elem),
         apf "notElem" (t prop_notElem),
         apf "find" (t prop_find),


### PR DESCRIPTION
These are definable for any ListLike and potentially useful
(Data.List exposes stripPrefix). On the other hand, Text has
special implementations of both of them that we'd like to
take advantage of, so it belongs in the typeclass itself.