### PR TITLE
Bumped upper version bound for containers

### DIFF
--- a/ListLike.cabal
+++ b/ListLike.cabal
@@ -50,7 +50,7 @@ Library
           Data.ListLike.FMList
   -- Other-Modules: Data.ConfigFile.Lexer
   Build-Depends: base       >= 4.6   && < 5
-                ,containers >= 0.3   && < 0.6
+                ,containers >= 0.3   && < 0.7
                 ,bytestring >= 0.9.1 && < 0.11
                 ,array      >= 0.3   && < 0.6
                 ,text       >= 0.11  && < 1.3


### PR DESCRIPTION
GHC 8.6.1-alpha2 was [announced](https://mail.haskell.org/pipermail/glasgow-haskell-users/2018-July/026776.html) and it includes containers 0.6.0.1, so I bumped the upper version bound for containers.

Blocking https://github.com/agda/agda/issues/3160.